### PR TITLE
Add related repository links for Difix3D and gsplat

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,18 @@
   * <a href="#213-3dgs-mcmc">3D Gaussian Splatting as Markov Chain Monte Carlo (2.13.)</a>
   * <a href="#214-feature-distillation">Feature distillation (2.14.)</a>
   * <a href="#215-in-the-wild">In the wild (2.15.)</a>
-  * <a href="#216-new-multiple-gpu-training-strategy">New Multiple GPU training strategy (2.16.)</a>
-  * <a href="#217-spotlesssplats">SpotLessSplats (2.17.)</a>
-  * <a href="#218-depth-regularization-with-depth-anything-v2">Depth Regularization with Depth Anything V2 (2.18.)</a>
-  * <a href="#219-stopthepop">StopThePop (2.19.)</a>
-  * <a href="#220-scale-regularization">Scale Regularization (2.20.)</a>
-  * <a href="#221-taming-3dgs">Taming 3DGS (2.21.)</a>
+* <a href="#216-new-multiple-gpu-training-strategy">New Multiple GPU training strategy (2.16.)</a>
+* <a href="#217-spotlesssplats">SpotLessSplats (2.17.)</a>
+* <a href="#218-depth-regularization-with-depth-anything-v2">Depth Regularization with Depth Anything V2 (2.18.)</a>
+* <a href="#219-stopthepop">StopThePop (2.19.)</a>
+* <a href="#220-scale-regularization">Scale Regularization (2.20.)</a>
+* <a href="#221-taming-3dgs">Taming 3DGS (2.21.)</a>
+
+## Related repositories
+
+- <a href="https://github.com/NVIDIA/Difix3D">Difix3D</a> – Original NVIDIA project that introduces the degradation-fixing pipeline reused in this repo.
+- <a href="https://github.com/nerfstudio-project/gsplat">gsplat</a> – Nerfstudio's Gaussian splatting rasterizer implementation referenced throughout this project.
+
 ## 1. Installation
 ### 1.1. Clone repository
 


### PR DESCRIPTION
## Summary
- add a "Related repositories" section to the README that links to the Difix3D and gsplat GitHub projects
- explain how each external project relates to the current implementation

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dd09c92e388323b2695493d3136b98